### PR TITLE
Various improvements

### DIFF
--- a/code/client/snd_dma.c
+++ b/code/client/snd_dma.c
@@ -584,6 +584,14 @@ static void S_Base_StartSoundEx( vec3_t origin, int entityNum, int entchannel, s
 	}
 
 	ch = s_channels;
+
+	// leilei - HACK - check if this sound is alredy playing and kill it, reduces distortion/awful firing sounds
+	for ( i = 0; i < MAX_CHANNELS ; i++, ch++ ) {		
+		if (ch->entnum == entityNum && ch->thesfx == sfx) {
+			S_ChannelFree(ch);
+			}
+	}
+
 	inplay = 0;
 	for ( i = 0; i < MAX_CHANNELS ; i++, ch++ ) {		
 		if (ch->entnum == entityNum && ch->thesfx == sfx) {

--- a/code/libretro/libretro.c
+++ b/code/libretro/libretro.c
@@ -72,6 +72,7 @@ void ( APIENTRY * qglViewport )(GLint x, GLint y, GLsizei width, GLsizei height)
 void ( APIENTRY * qglDeleteTextures )(GLsizei n, const GLuint *textures);
 void ( APIENTRY * qglClearStencil )(GLint s);
 void ( APIENTRY * qglColor4f )(GLfloat red, GLfloat green, GLfloat blue, GLfloat alpha);
+void ( APIENTRY * qglVertex2f )(GLfloat x, GLfloat y);
 void ( APIENTRY * qglScissor )(GLint x, GLint y, GLsizei width, GLsizei height);
 void ( APIENTRY * qglEnableClientState )(GLenum array);
 void ( APIENTRY * qglDisableClientState )(GLenum array);
@@ -82,6 +83,8 @@ void ( APIENTRY * qglDepthFunc )(GLenum func);
 void ( APIENTRY * qglTexEnvi )(GLenum target, GLenum pname, GLint param);
 void ( APIENTRY * qglAlphaFunc )(GLenum func,  GLclampf ref);
 void ( APIENTRY * qglClearDepth )(GLdouble depth);
+void ( APIENTRY * qglBegin )(GLenum mode);
+void ( APIENTRY * qglEnd )(void);
 void ( APIENTRY * qglFinish )(void);
 void ( APIENTRY * qglGenTextures )(GLsizei n,GLuint * textures);
 void ( APIENTRY * qglPolygonOffset )(GLfloat factor, GLfloat units);
@@ -798,6 +801,29 @@ static void update_variables(bool startup)
 			else
 				Cvar_SetValue("cg_drawFPS", 1);
 		}
+
+		var.key = "vitavoyager_overbrights";
+		var.value = NULL;
+
+		if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
+		{
+			if (strcmp(var.value, "disabled") == 0)
+				Cvar_SetValue("r_overbrightBits", 0);
+			else
+				Cvar_SetValue("r_overbrightBits", 1);
+		}
+
+		var.key = "vitavoyager_wide";
+		var.value = NULL;
+
+		if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
+		{
+			if (strcmp(var.value, "disabled") == 0)
+				Cvar_SetValue("r_widescreen", 0);
+			else
+				Cvar_SetValue("r_widescreen", 1);
+		}
+		
 		
 		var.key = "vitavoyager_pickups";
 		var.value = NULL;

--- a/code/libretro/libretro_core_options.h
+++ b/code/libretro/libretro_core_options.h
@@ -66,9 +66,40 @@ struct retro_core_option_definition option_defs_us[] = {
 		 { "1920x1080",   NULL },
 		 { "2560x1440",   NULL },
 		 { "3840x2160",   NULL },
+		 { "640x480",   NULL },
+		 { "800x600",   NULL },
+		 { "1024x768",   NULL },
+		 { "1152x864",   NULL },
+		 { "1280x960",   NULL },
+		 { "1400x1050",   NULL },
+		 { "1600x1200",   NULL },
+		 { "2048x1536",   NULL },
+		 { "856x480",   NULL },
          { NULL, NULL },
       },
-      "960x544"
+      "640x480"
+   },
+   {
+      "vitavoyager_overbrights",
+      "Overbrights",
+      "Increases the range of lighting while comprimising color precision. Requires a restart.",
+      {
+         { "disabled",  "Disabled" },
+         { "enabled",   "Enabled" },
+         { NULL, NULL },
+      },
+      "enabled"
+   },
+   {
+      "vitavoyager_wide",
+      "Widescreen",
+      "",
+      {
+         { "disabled",  "Vert-" },
+         { "enabled",   "Hor+" },
+         { NULL, NULL },
+      },
+      "enabled"
    },
    {
       "vitavoyager_invert_y_axis",
@@ -191,9 +222,40 @@ struct retro_core_option_definition option_defs_it[] = {
 		 { "1920x1080",   NULL },
 		 { "2560x1440",   NULL },
 		 { "3840x2160",   NULL },
+		 { "640x480",   NULL },
+		 { "800x600",   NULL },
+		 { "1024x768",   NULL },
+		 { "1152x864",   NULL },
+		 { "1280x960",   NULL },
+		 { "1400x1050",   NULL },
+		 { "1600x1200",   NULL },
+		 { "2048x1536",   NULL },
+		 { "856x480",   NULL },
          { NULL, NULL },
       },
-      "960x544"
+      "640x480"
+   },
+   {
+      "vitavoyager_overbrights",
+      "Overbrights",
+      "",
+      {
+         { "disabled",  "Disattivato" },
+         { "enabled",   "Attivato" },
+         { NULL, NULL },
+      },
+      "enabled"
+   },
+   {
+      "vitavoyager_wide",
+      "Widescreen",
+      "",
+      {
+         { "disabled",  "Vert-" },
+         { "enabled",   "Hor+" },
+         { NULL, NULL },
+      },
+      "enabled"
    },
    {
       "vitavoyager_invert_y_axis",

--- a/code/renderergl1/tr_backend.c
+++ b/code/renderergl1/tr_backend.c
@@ -1037,6 +1037,84 @@ const void *RB_ClearDepth(const void *data)
 
 /*
 =============
+RB_BrightScreen
+
+leilei - hack to add overbrights back in by rendering a blended plane. 
+	hopefully, the hardware libretro targets have a good enough fillrate to accept
+	this.  it's not a 1999 16bpp hell market anymore so what's the harm
+=============
+*/
+
+static int doneAltBrightness;
+
+void RB_BrightScreen( void )
+{
+	if ( doneAltBrightness )
+		return;
+	{
+		int eh, ah;
+		if ((r_overBrightBits->integer)) {
+			ah = r_overBrightBits->integer;
+			if (ah < 1) {
+				ah = 1;
+			}
+			if (ah > 2) {
+				ah = 2;   
+			}
+
+			// Blend method
+			// do a loop for every overbright bit enabled
+
+			for (eh=0; eh<ah; eh++)
+				{
+					//int vertexStart = tess.numVertexes;
+//					GL_State( GLS_DEPTHTEST_DISABLE | GLS_SRCBLEND_DST_COLOR | GLS_DSTBLEND_ONE );
+//					GL_Bind( tr.whiteImage );
+//					GL_Cull( CT_TWO_SIDED );
+				
+					RB_BeginSurface( tr.overbrightShader, 0 );
+					tess.xyz[tess.numVertexes][0] = 0;
+					tess.xyz[tess.numVertexes][1] = 0;
+					tess.numVertexes++;
+
+					tess.xyz[tess.numVertexes][0] = 0;
+					tess.xyz[tess.numVertexes][1] = glConfig.vidHeight;
+					tess.numVertexes++;
+
+					tess.xyz[tess.numVertexes][0] = glConfig.vidWidth;
+					tess.xyz[tess.numVertexes][1] = glConfig.vidHeight;
+					tess.numVertexes++;
+
+					tess.xyz[tess.numVertexes][0] = glConfig.vidWidth;
+					tess.xyz[tess.numVertexes][1] = 0;
+					tess.numVertexes++;
+
+
+					tess.indexes[tess.numIndexes++] = 0;
+					tess.indexes[tess.numIndexes++] = 1;
+					tess.indexes[tess.numIndexes++] = 2;
+					tess.indexes[tess.numIndexes++] = 0;
+					tess.indexes[tess.numIndexes++] = 2;
+					tess.indexes[tess.numIndexes++] = 3;
+
+				//	GL_State( GLS_DEPTHTEST_DISABLE | GLS_SRCBLEND_DST_COLOR | GLS_DSTBLEND_ONE );
+				//	GL_Bind( tr.whiteImage );
+				//	GL_Cull( CT_TWO_SIDED );
+
+					RB_EndSurface();
+
+
+
+				}
+			doneAltBrightness = qtrue;
+		}
+	}
+
+}
+
+
+/*
+=============
 RB_SwapBuffers
 
 =============
@@ -1056,6 +1134,8 @@ const void	*RB_SwapBuffers( const void *data ) {
 
 	cmd = (const swapBuffersCommand_t *)data;
 
+	RB_BrightScreen();
+
 	if ( !glState.finishCalled ) {
 		qglFinish();
 	}
@@ -1066,6 +1146,7 @@ const void	*RB_SwapBuffers( const void *data ) {
 
 	backEnd.projection2D = qfalse;
 
+	doneAltBrightness=0;
 	return (const void *)(cmd + 1);
 }
 

--- a/code/renderergl1/tr_image.c
+++ b/code/renderergl1/tr_image.c
@@ -673,7 +673,8 @@ static void Upload32( unsigned *data,
 		Com_Memcpy( scaledBuffer, data, width * height * 4 );
 	}
 
-	R_LightScaleTexture (scaledBuffer, scaled_width, scaled_height, !mipmap );
+	// leilei - don't do this! q2 leftover oversight makes stuff ugly
+	//R_LightScaleTexture (scaledBuffer, scaled_width, scaled_height, !mipmap );
 
 	*pUploadWidth = scaled_width;
 	*pUploadHeight = scaled_height;
@@ -1149,6 +1150,9 @@ void R_SetColorMappings( void ) {
 
 	// setup the overbright lighting
 	tr.overbrightBits = r_overBrightBits->integer;
+
+	// leilei - overbrights hack
+	/*
 	if ( !glConfig.deviceSupportsGamma ) {
 		tr.overbrightBits = 0;		// need hardware gamma for overbright
 	}
@@ -1158,6 +1162,8 @@ void R_SetColorMappings( void ) {
 	{
 		tr.overbrightBits = 0;
 	}
+
+	*/
 
 	// allow 2 overbright bits in 24 bit, but only 1 in 16 bit
 	if ( glConfig.colorBits > 16 ) {

--- a/code/renderergl1/tr_init.c
+++ b/code/renderergl1/tr_init.c
@@ -145,6 +145,7 @@ cvar_t  *r_noborder;
 cvar_t	*r_customwidth;
 cvar_t	*r_customheight;
 cvar_t	*r_customPixelAspect;
+cvar_t	*r_widescreen;
 
 cvar_t	*r_overBrightBits;
 cvar_t	*r_mapOverBrightBits;
@@ -240,15 +241,21 @@ vidmode_t r_vidModes[] =
 	{ "Mode  1: 640x368",		640,	368,	1 },
 	{ "Mode  2: 720x408",		720,	408,	1 },
 	{ "Mode  3: 960x544",		960,	544,	1 },
-	{ "Mode  4: 960x544",		960,	544,	1 },
-	{ "Mode  5: 960x544",		960,	544,	1 },
-	{ "Mode  6: 960x544",		960,	544,	1 },
-	{ "Mode  7: 960x544",		960,	544,	1 },
-	{ "Mode  8: 960x544",		960,	544,	1 },
-	{ "Mode  9: 960x544",		960,	544,	1 },
-	{ "Mode 10: 960x544",		960,	544,	1 },
-	{ "Mode 11: 960x544",		960,	544,	1 }
+	{ "Mode  4: 1280x720",		1280,	720,	1 },
+	{ "Mode  5: 1920x1080",		1920,	1080,	1 },
+	{ "Mode  6: 2560x1440",		2560,	1440,	1 },
+	{ "Mode  7: 3840x2160",		3840,	2160,	1 },
+	{ "Mode  8: 640x480",		640,	480,	1 },
+	{ "Mode  9: 800x600",		800,	600,	1 },
+	{ "Mode 10: 1024x768",		1024,	768,	1 },
+	{ "Mode 11: 1152x864",		1152,	864,	1 },
+	{ "Mode 12: 1280x960",		1280,	960,	1 },
+	{ "Mode 13: 1400x1050",		1400,	1050,	1 },
+	{ "Mode 14: 1600x1200",		1600,	1200,	1 },
+	{ "Mode 15: 2048x1536",		2048,	1536,	1 },
+	{ "Mode 16: 856x480",		856,	480,	1 }
 };
+
 static int	s_numVidModes = ARRAY_LEN( r_vidModes );
 
 qboolean R_GetModeInfo( int *width, int *height, float *windowAspect, int mode ) {
@@ -840,6 +847,7 @@ void R_Register( void )
 	r_ext_multisample = ri.Cvar_Get( "r_ext_multisample", "0", CVAR_ARCHIVE | CVAR_LATCH );
 	ri.Cvar_CheckRange( r_ext_multisample, 0, 4, qtrue );
 	r_overBrightBits = ri.Cvar_Get ("r_overBrightBits", "1", CVAR_ARCHIVE | CVAR_LATCH );
+	r_widescreen = ri.Cvar_Get ("r_widescreen", "1", CVAR_ARCHIVE );
 	r_ignorehwgamma = ri.Cvar_Get( "r_ignorehwgamma", "0", CVAR_ARCHIVE | CVAR_LATCH);
 	r_mode = ri.Cvar_Get( "r_mode", "3", CVAR_ARCHIVE | CVAR_LATCH );
 	r_fullscreen = ri.Cvar_Get( "r_fullscreen", "1", CVAR_ARCHIVE );

--- a/code/renderergl1/tr_local.h
+++ b/code/renderergl1/tr_local.h
@@ -913,6 +913,8 @@ typedef struct {
 	shader_t				*flareShader;
 	shader_t				*sunShader;
 
+	shader_t				*overbrightShader;
+
 	int						numLightmaps;
 	image_t					**lightmaps;
 
@@ -1066,6 +1068,8 @@ extern	cvar_t	*r_anaglyphMode;
 extern	cvar_t	*r_greyscale;
 
 extern	cvar_t	*r_ignoreGLErrors;
+
+extern	cvar_t	*r_widescreen;
 
 extern	cvar_t	*r_overBrightBits;
 extern	cvar_t	*r_mapOverBrightBits;

--- a/code/renderergl1/tr_scene.c
+++ b/code/renderergl1/tr_scene.c
@@ -391,6 +391,35 @@ void RE_RenderScene( const refdef_t *fd ) {
 
 	parms.fovX = tr.refdef.fov_x;
 	parms.fovY = tr.refdef.fov_y;
+
+	// leilei - widescreen
+	// recalculate fov according to widescreen parameters
+	if (!( fd->rdflags & RDF_NOWORLDMODEL ) && r_widescreen->integer) // don't affect interface refdefs
+	{
+		float zoomfov = tr.refdef.fov_x / 90;	// figure out our zoom or changed fov magnitiude from cg_fov and cg_zoomfov
+		int thisisit;
+
+		// find aspect to immediately match our vidwidth for perfect match with resized screens...
+		float erspact = tr.refdef.width / tr.refdef.height;
+		float aspact = glConfig.vidWidth / glConfig.vidHeight;
+		if (erspact == aspact) thisisit = 1;
+	
+		// try not to recalculate fov of ui and hud elements
+		if (((tr.refdef.fov_x /  tr.refdef.fov_y) > 1.3) && (thisisit))
+
+			{
+			// undo vert-
+			parms.fovY = parms.fovY * (73.739792 / tr.refdef.fov_y) * zoomfov;
+			
+			// recalculate the fov
+			parms.fovX = (atan (glConfig.vidWidth / (glConfig.vidHeight / tan ((parms.fovY * M_PI) / 360.0f))) * 360.0f) / M_PI;
+			parms.fovY = (atan (glConfig.vidHeight / (glConfig.vidWidth / tan ((parms.fovX * M_PI) / 360.0f))) * 360.0f) / M_PI;
+			}
+	}
+
+	// leilei - end
+
+
 	
 	parms.stereoFrame = tr.refdef.stereoFrame;
 

--- a/code/renderergl1/tr_shade_calc.c
+++ b/code/renderergl1/tr_shade_calc.c
@@ -900,22 +900,42 @@ void RB_CalcEnvironmentTexCoords( float *st )
 
 	v = tess.xyz[0];
 	normal = tess.normal[0];
-
-	for (i = 0 ; i < tess.numVertexes ; i++, v += 4, normal += 4, st += 2 ) 
+	if (backEnd.currentEntity->e.renderfx & RF_FIRST_PERSON) // Weapons
 	{
-		VectorSubtract (backEnd.or.viewOrigin, v, viewer);
-		VectorNormalizeFast (viewer);
+		for (i = 0 ; i < tess.numVertexes ; i++, v += 4, normal += 4, st += 2 ) 
+		{
+			VectorCopy (backEnd.currentEntity->lightDir, viewer);
+			VectorNormalizeFast (viewer);
 
-		d = DotProduct (normal, viewer);
-
-		reflected[0] = normal[0]*2*d - viewer[0];
-		reflected[1] = normal[1]*2*d - viewer[1];
-		reflected[2] = normal[2]*2*d - viewer[2];
-
-		st[0] = 0.5 + reflected[1] * 0.5;
-		st[1] = 0.5 - reflected[2] * 0.5;
+			d = DotProduct (normal, viewer);
+	
+			reflected[0] = normal[0]*2*d - viewer[0];
+			reflected[1] = normal[1]*2*d - viewer[1];
+			reflected[2] = normal[2]*2*d - viewer[2];
+	
+			st[0] = 0.5 + reflected[1] * 0.5;
+			st[1] = 0.5 - reflected[2] * 0.5;
+		}
+	}
+	else	// World
+	{
+		for (i = 0 ; i < tess.numVertexes ; i++, v += 4, normal += 4, st += 2 ) 
+		{
+			VectorSubtract (backEnd.or.viewOrigin, v, viewer);
+			VectorNormalizeFast (viewer);
+	
+			d = DotProduct (normal, viewer);
+	
+			reflected[0] = normal[0]*2*d - viewer[0];
+			reflected[1] = normal[1]*2*d - viewer[1];
+			reflected[2] = normal[2]*2*d - viewer[2];
+	
+			st[0] = 0.5 + reflected[1] * 0.5;
+			st[1] = 0.5 - reflected[2] * 0.5;
+		}
 	}
 }
+
 
 /*
 ** RB_CalcTurbulentTexCoords
@@ -1037,6 +1057,14 @@ void RB_CalcSpecularAlpha( unsigned char *alphas ) {
 	vec3_t		lightDir;
 	int			numVertexes;
 
+	// leilei - Try to approximate stvoy's specular
+	vec3_t lightOrg;
+	if (backEnd.currentEntity->e.renderfx & RF_FIRST_PERSON)
+	{
+		VectorCopy(backEnd.currentEntity->lightDir, lightOrg);
+		VectorNormalizeFast( lightOrg );
+	}
+
 	v = tess.xyz[0];
 	normal = tess.normal[0];
 
@@ -1046,7 +1074,7 @@ void RB_CalcSpecularAlpha( unsigned char *alphas ) {
 	for (i = 0 ; i < numVertexes ; i++, v += 4, normal += 4, alphas += 4) {
 		float ilength;
 
-		VectorSubtract( lightOrigin, v, lightDir );
+		VectorSubtract( lightOrg, v, lightDir );
 //		ilength = Q_rsqrt( DotProduct( lightDir, lightDir ) );
 		VectorNormalizeFast( lightDir );
 

--- a/code/renderergl1/tr_shader.c
+++ b/code/renderergl1/tr_shader.c
@@ -3152,6 +3152,24 @@ static void CreateInternalShaders( void ) {
 	Q_strncpyz( shader.name, "<stencil shadow>", sizeof( shader.name ) );
 	shader.sort = SS_STENCIL_SHADOW;
 	tr.shadowShader = FinishShader();
+
+}
+
+static void CreateOBShader (void)
+{
+
+	// leilei - make overbright shader (portability hack)
+	InitShader( "<overbrights>", LIGHTMAP_NONE );
+	stages[0].bundle[0].image[0] = tr.whiteImage;
+	stages[0].active = qtrue;
+	shader.cullType = CT_TWO_SIDED;
+	stages[0].stateBits = GLS_SRCBLEND_DST_COLOR | GLS_DSTBLEND_ONE ;
+	stages[0].constantColor[0] = 255;
+	stages[0].constantColor[1] = 255;
+	stages[0].constantColor[2] = 255;
+	stages[0].rgbGen = CGEN_CONST;
+	//shader.sort = SS_NEAREST;
+	tr.overbrightShader = FinishShader();
 }
 
 static void CreateExternalShaders( void ) {
@@ -3189,4 +3207,6 @@ void R_InitShaders( void ) {
 	ScanAndLoadShaderFiles();
 
 	CreateExternalShaders();
+
+	CreateOBShader();
 }


### PR DESCRIPTION
- Widescreen is done in the renderer and should be compatible.  No fov compensation necessary.

- Overbrights are done by blending a polygon over the screen.  This is rewritten and is not an OA copypaste, since OA uses GL directly for that, and for this one i'd have to make an internal shader then get it through the tess system.

- Sound interruption is an experiment to recreate the pre-q31.27g sound system's channel playback, however this is not yet perfectly accurate. It's better than nothing though, tetrion firing sounds 605% less annoying.

- Other stvoy renderer accuracy fixes include: Weapon shines and specular calculation are recreated from visual analysis of stvoyhm.exe and trial and error. SpecularAlpha fetches from the lightdirection instead of a fixed world position. EnvironmentTexCoords reflects from the light direction for first person models, and goes with XY rather than YZ.

- Flares work. The flares are a trace check, which should work on all platforms (normally, they'd have to be a pixel read - but I have no idea on how to do that through RA's GL).. Other than that, i've taken extra care to recreate their proper sizes seen in stvoyhm.

- I've added a bunch of standard, supported-by-the-game 4:3 resolutions plus the usual 16:9 resolutions, which breaks the "vita" part of the name and philosophy a bit, I'd suggest going further and make the previous Vita resolutions a compile option for those.  This is probably likely the most objectionable part of the pull. I'd recommend at least having 640x480 as that's the game's native resolution for all 2D elements.

There are other things I wanted to do (true analog control for player movement on the left stick (see the joystick code), fixing the sky seam and flashes, investigating hm_borg teleporter shaders) but couldn't find much time to look into them.